### PR TITLE
Accept a "data" property as additional metadata

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,9 @@ function File(file) {
   // TODO: should this be moved to vinyl-fs?
   this.stat = file.stat || null;
 
+  // Meta data property for passing data to other plugins (see gulp-data)
+  this.data = file.data || null;
+
   // contents = stream, buffer, or null if not read
   this.contents = file.contents || null;
 }


### PR DESCRIPTION
I'm developing a standard methodology for passing meta data to plugins using a separate plugin called `gulp-data` (see https://www.npmjs.org/package/gulp-data). It all works fine without this change, but when writing gulp plugin unit tests by instantiating a File object with the data property attached, the tests fail. It looks like setting a default value here fixes that. Now I can write tests on adhoc files:

```
var srcFile = new gutil.File({
  path: "test/fixtures/filepath.txt",
  cwd: "test/",
  base: "test/fixtures",
  contents: new Buffer("Fake data"),
  data: { message: "Some data" }
});
```
