### PR TITLE
Set atime, mtime and ctime from contents accessors

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,19 @@ function File(file) {
   // Stat = files stats object
   this.stat = file.stat || null;
 
+  // Make sure times are proper Date objects
+  if (this.stat) {
+    if (typeof this.stat.atime === 'number') {
+      this.stat.atime = new Date(this.stat.atime);
+    }
+    if (typeof this.stat.mtime === 'number') {
+      this.stat.mtime = new Date(this.stat.mtime);
+    }
+    if (typeof this.stat.ctime === 'number') {
+      this.stat.ctime = new Date(this.stat.ctime);
+    }
+  }
+
   this._isVinyl = true;
 }
 

--- a/index.js
+++ b/index.js
@@ -21,11 +21,11 @@ function File(file) {
   this.cwd = file.cwd || process.cwd();
   this.base = file.base || this.cwd;
 
-  // Stat = files stats object
-  this.stat = file.stat || null;
-
   // Contents = stream, buffer, or null if not read
   this.contents = file.contents || null;
+
+  // Stat = files stats object
+  this.stat = file.stat || null;
 
   this._isVinyl = true;
 }
@@ -149,11 +149,23 @@ File.isVinyl = function(file) {
 // Or stuff with extra logic
 Object.defineProperty(File.prototype, 'contents', {
   get: function() {
+    if (this.stat && this.stat.atime) {
+      this.stat.atime.setTime(Date.now());
+    }
     return this._contents;
   },
   set: function(val) {
     if (!isBuffer(val) && !isStream(val) && !isNull(val)) {
       throw new Error('File.contents can only be a Buffer, a Stream, or null.');
+    }
+    if (this.stat) {
+      var now = Date.now();
+      if (this.stat.mtime) {
+        this.stat.mtime.setTime(now);
+      }
+      if (this.stat.ctime) {
+        this.stat.ctime.setTime(now);
+      }
     }
     this._contents = val;
   },

--- a/test/File.js
+++ b/test/File.js
@@ -651,6 +651,32 @@ describe('File', function() {
         done();
       }
     });
+
+    it('should update atime when reading contents', function(done) {
+      var earlier = Date.now() - 1000;
+      var file = new File({
+        stat: {
+          atime: new Date(earlier),
+        },
+      });
+      var contents = file.contents;
+      file.stat.atime.getTime().should.be.above(earlier);
+      done();
+    });
+
+    it('should update mtime and ctime when writing contents', function(done) {
+      var earlier = Date.now() - 1000;
+      var file = new File({
+        stat: {
+          mtime: new Date(earlier),
+          ctime: new Date(earlier),
+        },
+      });
+      file.contents = new Buffer('test');
+      file.stat.mtime.getTime().should.be.above(earlier);
+      file.stat.ctime.getTime().should.be.above(earlier);
+      done();
+    });
   });
 
   describe('relative get/set', function() {

--- a/test/File.js
+++ b/test/File.js
@@ -652,6 +652,21 @@ describe('File', function() {
       }
     });
 
+    it('should coerce integer stat.xtime to proper Date objects', function(done) {
+      var now = Date.now();
+      var file = new File({
+        stat: {
+          atime: now,
+          mtime: now,
+          ctime: now,
+        },
+      });
+      (file.stat.atime instanceof Date).should.equal(true);
+      (file.stat.mtime instanceof Date).should.equal(true);
+      (file.stat.ctime instanceof Date).should.equal(true);
+      done();
+    });
+
     it('should update atime when reading contents', function(done) {
       var earlier = Date.now() - 1000;
       var file = new File({


### PR DESCRIPTION
As discussed in [#1461](https://github.com/gulpjs/gulp/issues/1461), I think this covers the simple case.

Note: I had to adjust tests in `vinyl-fs` to get them to pass against `vinyl` with this patch, will submit a PR for that as well.

Edit: and [here](https://github.com/gulpjs/vinyl-fs/pull/143) it is.