### PR TITLE
chore: add NPM script for changelog

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "eslint": "^1.7.3",
     "eslint-config-gulp": "^2.0.0",
     "event-stream": "^3.1.0",
+    "github-changes": "^1.0.1",
     "istanbul": "^0.3.0",
     "istanbul-coveralls": "^1.0.1",
     "jscs": "^2.3.5",
@@ -33,7 +34,8 @@
     "lint": "eslint . && jscs *.js lib/ test/",
     "pretest": "npm run lint",
     "test": "mocha",
-    "coveralls": "istanbul cover _mocha && istanbul-coveralls"
+    "coveralls": "istanbul cover _mocha && istanbul-coveralls",
+    "changelog": "github-changes -o gulpjs -r vinyl -b master -f ./CHANGELOG.md --order-semver --use-commit-body"
   },
   "engines": {
     "node": ">= 0.9"


### PR DESCRIPTION
As discussed in #76 this PR adds an NPM script for changelog creation.

Please note that github-changes is a bit greedy towards Github API. As is, the script is limited with [Github's API limits](https://developer.github.com/v3/#rate-limiting). `github-changes` has a way to authenticate in order to get a higher rate limit, using a Github API token. However, this kind of token-based authentication can not be hard-coded, since tokens must remain secret.

To circumvent this, one could install `github-changes` globally, and run
```
github-changes -o gulpjs -r vinyl -b master -f ./CHANGELOG.md --order-semver --use-commit-body -a -k YOUR_GITHUB_TOKEN
```