### PR TITLE
Clone with constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ File.prototype.clone = function(opt) {
     contents = opt.contents ? cloneBuffer(this.contents) : this.contents;
   }
 
-  var file = new File({
+  var file = new this.constructor({
     cwd: this.cwd,
     base: this.base,
     stat: (this.stat ? cloneStats(this.stat) : null),

--- a/test/File.js
+++ b/test/File.js
@@ -420,6 +420,30 @@ describe('File', function() {
 
       done();
     });
+
+    it('should work with extended files', function(done) {
+      function ExtendedFile() {
+        File.apply(this, arguments);
+      }
+      ExtendedFile.prototype = Object.create(File.prototype);
+      ExtendedFile.prototype.constructor = ExtendedFile;
+      // Object.setPrototypeOf(ExtendedFile, File);
+      // Just copy static stuff since Object.setPrototypeOf is node >=0.12
+      Object.keys(File).forEach(function(key) {
+        ExtendedFile[key] = File[key];
+      });
+
+      var file = new ExtendedFile();
+      var file2 = file.clone();
+
+      file2.should.not.equal(file, 'refs should be different');
+      file2.constructor.should.equal(ExtendedFile);
+      (file2 instanceof ExtendedFile).should.equal(true);
+      (file2 instanceof File).should.equal(true);
+      ExtendedFile.prototype.isPrototypeOf(file2).should.equal(true);
+      File.prototype.isPrototypeOf(file2).should.equal(true);
+      done();
+    });
   });
 
   describe('pipe()', function() {


### PR DESCRIPTION
Changes `#clone()` to return `new this.constructor()` instead of `new File()` so it works properly even on objects extended from Vinyl.