### PR TITLE
Make constructor set custom properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,10 @@ var inspectStream = require('./lib/inspectStream');
 var Stream = require('stream');
 var replaceExt = require('replace-ext');
 
+var builtInFields = [
+  '_contents', 'contents', 'stat', 'history', 'path', 'base', 'cwd',
+];
+
 function File(file) {
   if (!file) {
     file = {};
@@ -145,9 +149,6 @@ File.prototype.inspect = function() {
 };
 
 File.isCustomProp = function(key) {
-  var builtInFields = [
-    '_contents', 'contents', 'stat', 'history', 'path', 'base', 'cwd',
-  ];
   return builtInFields.indexOf(key) === -1;
 };
 

--- a/index.js
+++ b/index.js
@@ -14,6 +14,8 @@ var builtInFields = [
 ];
 
 function File(file) {
+  var self = this;
+
   if (!file) {
     file = {};
   }
@@ -35,10 +37,10 @@ function File(file) {
 
   // Set custom properties
   Object.keys(file).forEach(function(key) {
-    if (this.constructor.isCustomProp(key)) {
-      this[key] = file[key];
+    if (self.constructor.isCustomProp(key)) {
+      self[key] = file[key];
     }
-  }, this);
+  });
 }
 
 File.prototype.isBuffer = function() {
@@ -59,6 +61,8 @@ File.prototype.isDirectory = function() {
 };
 
 File.prototype.clone = function(opt) {
+  var self = this;
+
   if (typeof opt === 'boolean') {
     opt = {
       deep: opt,
@@ -93,10 +97,10 @@ File.prototype.clone = function(opt) {
 
   // Clone our custom properties
   Object.keys(this).forEach(function(key) {
-    if (this.constructor.isCustomProp(key)) {
-      file[key] = opt.deep ? clone(this[key], true) : this[key];
+    if (self.constructor.isCustomProp(key)) {
+      file[key] = opt.deep ? clone(self[key], true) : self[key];
     }
-  }, this);
+  });
   return file;
 };
 

--- a/index.js
+++ b/index.js
@@ -144,10 +144,11 @@ File.prototype.inspect = function() {
   return '<File ' + inspect.join(' ') + '>';
 };
 
-File.builtInFields = ['_contents', 'contents', 'stat', 'history', 'path', 'base', 'cwd'];
-
 File.isCustomProp = function(key) {
-  return this.builtInFields.indexOf(key) === -1;
+  var builtInFields = [
+    '_contents', 'contents', 'stat', 'history', 'path', 'base', 'cwd',
+  ];
+  return builtInFields.indexOf(key) === -1;
 };
 
 File.isVinyl = function(file) {

--- a/index.js
+++ b/index.js
@@ -28,6 +28,13 @@ function File(file) {
   this.contents = file.contents || null;
 
   this._isVinyl = true;
+
+  // Set custom properties
+  Object.keys(file).forEach(function(key) {
+    if (this.constructor.isCustomProp(key)) {
+      this[key] = file[key];
+    }
+  }, this);
 }
 
 File.prototype.isBuffer = function() {
@@ -82,13 +89,9 @@ File.prototype.clone = function(opt) {
 
   // Clone our custom properties
   Object.keys(this).forEach(function(key) {
-    // Ignore built-in fields
-    if (key === '_contents' || key === 'stat' ||
-      key === 'history' || key === 'path' ||
-      key === 'base' || key === 'cwd') {
-      return;
+    if (this.constructor.isCustomProp(key)) {
+      file[key] = opt.deep ? clone(this[key], true) : this[key];
     }
-    file[key] = opt.deep ? clone(this[key], true) : this[key];
   }, this);
   return file;
 };
@@ -139,6 +142,12 @@ File.prototype.inspect = function() {
   }
 
   return '<File ' + inspect.join(' ') + '>';
+};
+
+File.builtInFields = ['_contents', 'contents', 'stat', 'history', 'path', 'base', 'cwd'];
+
+File.isCustomProp = function(key) {
+  return this.builtInFields.indexOf(key) === -1;
 };
 
 File.isVinyl = function(file) {

--- a/test/File.js
+++ b/test/File.js
@@ -110,6 +110,13 @@ describe('File', function() {
       file.contents.should.equal(val);
       done();
     });
+
+    it('should set custom properties', function(done) {
+      var sourceMap = {};
+      var file = new File({ sourceMap: sourceMap });
+      file.sourceMap.should.equal(sourceMap);
+      done();
+    });
   });
 
   describe('isBuffer()', function() {


### PR DESCRIPTION
Currently, when doing this:

```js
var file = new Vinyl({
  path: __dirname + '/index.js',
  sourceMap: {}
});
```

`sourceMap` and any other custom properties are ignored. This PR will make constructor extend `this` with all custom props passed in the configuration object.

It'll make creating Vinyl files a bit faster and more comfy.

I'm also moving check for custom properties from that multiline `if` statement to a dedicated static method `File.isCustomProp(key)` which relies on `File.builtInFields` array to check if a key is a custom property.

This is than used in `#clone()`, as well as constructor, and could be used in `#toJSON()` method from other PR.

It also allows anyone that extends from `Vinyl` to extend their `ExtendedVinyl.builtInFields` with their own props that shouldn't be cloned.