### PR TITLE
Added test for clone stream behavior and bumped cloneable-readable

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "clone": "^1.0.0",
     "clone-stats": "^1.0.0",
-    "cloneable-readable": "^0.1.0",
+    "cloneable-readable": "^0.2.0",
     "readable-stream": "^2.1.0",
     "replace-ext": "^1.0.0"
   },


### PR DESCRIPTION
@phated I've added a test, and found a bug in `cloneable-readable` in the process.
The test fails on master, meaning that the clone is keeping the content of the stream in memory.

I've also make it error if cloning a stream that was already started.

See #102.