### PR TITLE
Bumped cloneable-readable v0.4.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "clone": "^1.0.0",
     "clone-stats": "^1.0.0",
-    "cloneable-readable": "^0.3.0",
+    "cloneable-readable": "^0.4.0",
     "readable-stream": "^2.1.0",
     "replace-ext": "^1.0.0"
   },


### PR DESCRIPTION
To address for https://github.com/mcollina/cloneable-readable/pull/2