### PR TITLE
Add documentation for `file.stat`

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,15 @@ Array of `file.path` values the Vinyl object has had, from `file.history[0]` (or
 
 Type: `Array`
 
+#### `file.stat`
+
+The result of an `fs.stat` call. This is how the file is marked as a directory
+or symbolic link. See [isDirectory()][is-directory],
+[isSymbolic()][is-symbolic] and [fs.Stats][fs-stats] for more information.
+
+Type: [`fs.Stats`][fs-stats]
+
+
 #### `file.relative`
 
 Gets the result of `path.relative(file.base, file.path)`.


### PR DESCRIPTION
This PR follows #119 

It documents the `file.stat` property of `Vinyl` instances.

This is a simple property, without any getter or setter; but it is accessible and has a meaning so this should be documented: it's a part of the API.
