### PR TITLE
Use v1.0.0 of cloneable-readable

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "clone": "^1.0.0",
     "clone-buffer": "^1.0.0",
     "clone-stats": "^1.0.0",
-    "cloneable-readable": "^0.5.0",
+    "cloneable-readable": "^1.0.0",
     "is-stream": "^1.1.0",
     "remove-trailing-separator": "^1.0.1",
     "replace-ext": "^1.0.0"


### PR DESCRIPTION
Nothing change, but this mark cloneable-readable as stable.
