### PR TITLE
Fix: update custom inspection to use a symbol

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var path = require('path');
+var util = require('util');
 var isBuffer = require('buffer').Buffer.isBuffer;
 
 var clone = require('clone');
@@ -156,6 +157,11 @@ File.prototype.inspect = function() {
 
   return '<File ' + inspect.join(' ') + '>';
 };
+
+// Newer Node.js versions use this symbol for custom inspection.
+if (util.inspect.custom) {
+  File.prototype[util.inspect.custom] = File.prototype.inspect;
+}
 
 File.isCustomProp = function(key) {
   return builtInFields.indexOf(key) === -1;

--- a/test/file.js
+++ b/test/file.js
@@ -2,6 +2,7 @@
 
 var fs = require('fs');
 var path = require('path');
+var util = require('util');
 var expect = require('expect');
 var miss = require('mississippi');
 var cloneable = require('cloneable-readable');
@@ -746,7 +747,12 @@ describe('File', function() {
 
     it('returns correct format when no contents and no path', function(done) {
       var file = new File();
-      expect(file.inspect()).toEqual('<File >');
+      var expectation = '<File >';
+      expect(file.inspect()).toEqual(expectation);
+      expect(util.inspect(file)).toEqual(expectation);
+      if (util.inspect.custom) {
+        expect(file[util.inspect.custom]()).toEqual(expectation);
+      }
       done();
     });
 


### PR DESCRIPTION
Node.js 11 removed support for the `inspect` property on objects as
custom inspect functions. Instead, this can be done by using the
util.inspect.custom symbol that is used here instead. To keep it
backwarts compatible the old function stays in place.

The README actually has a reference to this as well. However, the old
inspect function will not be called by Node.js 11 anymore. I am not really
sure how to properly reflect that and just kept it as it is.