### PR TITLE
Do not use the deprecated Buffer() constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ var jsFile = new Vinyl({
   cwd: '/',
   base: '/test/',
   path: '/test/file.js',
-  contents: new Buffer('var x = 123')
+  contents: Buffer.from('var x = 123')
 });
 ```
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "jscs": "^2.3.5",
     "jscs-preset-gulp": "^1.0.0",
     "mississippi": "^1.2.0",
-    "mocha": "^2.4.5"
+    "mocha": "^2.4.5",
+    "safer-buffer": "^2.1.2"
   },
   "keywords": [
     "virtual",

--- a/test/file.js
+++ b/test/file.js
@@ -6,6 +6,7 @@ var util = require('util');
 var expect = require('expect');
 var miss = require('mississippi');
 var cloneable = require('cloneable-readable');
+var saferBuffer = require('safer-buffer');
 
 var File = require('../');
 
@@ -13,6 +14,7 @@ var pipe = miss.pipe;
 var from = miss.from;
 var concat = miss.concat;
 var isCloneable = cloneable.isCloneable;
+var Buffer = saferBuffer.Buffer;
 
 var isWin = (process.platform === 'win32');
 
@@ -162,7 +164,7 @@ describe('File', function() {
     });
 
     it('sets contents', function(done) {
-      var val = new Buffer('test');
+      var val = Buffer.from('test');
       var file = new File({ contents: val });
       expect(file.contents).toEqual(val);
       done();
@@ -269,7 +271,7 @@ describe('File', function() {
   describe('isBuffer()', function() {
 
     it('returns true when the contents are a Buffer', function(done) {
-      var val = new Buffer('test');
+      var val = Buffer.from('test');
       var file = new File({ contents: val });
       expect(file.isBuffer()).toEqual(true);
       done();
@@ -292,7 +294,7 @@ describe('File', function() {
   describe('isStream()', function() {
 
     it('returns false when the contents are a Buffer', function(done) {
-      var val = new Buffer('test');
+      var val = Buffer.from('test');
       var file = new File({ contents: val });
       expect(file.isStream()).toEqual(false);
       done();
@@ -315,7 +317,7 @@ describe('File', function() {
   describe('isNull()', function() {
 
     it('returns false when the contents are a Buffer', function(done) {
-      var val = new Buffer('test');
+      var val = Buffer.from('test');
       var file = new File({ contents: val });
       expect(file.isNull()).toEqual(false);
       done();
@@ -343,7 +345,7 @@ describe('File', function() {
     };
 
     it('returns false when the contents are a Buffer', function(done) {
-      var val = new Buffer('test');
+      var val = Buffer.from('test');
       var file = new File({ contents: val, stat: fakeStat });
       expect(file.isDirectory()).toEqual(false);
       done();
@@ -383,7 +385,7 @@ describe('File', function() {
     };
 
     it('returns false when the contents are a Buffer', function(done) {
-      var val = new Buffer('test');
+      var val = Buffer.from('test');
       var file = new File({ contents: val, stat: fakeStat });
       expect(file.isSymbolic()).toEqual(false);
       done();
@@ -422,7 +424,7 @@ describe('File', function() {
         cwd: '/',
         base: '/test/',
         path: '/test/test.coffee',
-        contents: new Buffer('test'),
+        contents: Buffer.from('test'),
       };
       var file = new File(options);
       var file2 = file.clone();
@@ -441,7 +443,7 @@ describe('File', function() {
         cwd: '/',
         base: '/test/',
         path: '/test/test.js',
-        contents: new Buffer('test'),
+        contents: Buffer.from('test'),
       };
       var file = new File(options);
 
@@ -598,7 +600,7 @@ describe('File', function() {
         cwd: '/',
         base: '/test/',
         path: '/test/test.js',
-        contents: new Buffer('test'),
+        contents: Buffer.from('test'),
         stat: fs.statSync(__filename),
       };
 
@@ -617,7 +619,7 @@ describe('File', function() {
         cwd: path.normalize('/'),
         base: path.normalize('/test/'),
         path: path.normalize('/test/test.js'),
-        contents: new Buffer('test'),
+        contents: Buffer.from('test'),
       };
 
       var file = new File(options);
@@ -757,14 +759,14 @@ describe('File', function() {
     });
 
     it('returns correct format when Buffer contents and no path', function(done) {
-      var val = new Buffer('test');
+      var val = Buffer.from('test');
       var file = new File({ contents: val });
       expect(file.inspect()).toEqual('<File <Buffer 74 65 73 74>>');
       done();
     });
 
     it('returns correct format when Buffer contents and relative path', function(done) {
-      var val = new Buffer('test');
+      var val = Buffer.from('test');
       var file = new File({
         cwd: '/',
         base: '/test/',
@@ -801,7 +803,7 @@ describe('File', function() {
   describe('contents get/set', function() {
 
     it('returns _contents', function(done) {
-      var val = new Buffer('test');
+      var val = Buffer.from('test');
       var file = new File();
       file._contents = val;
       expect(file.contents).toEqual(val);
@@ -809,7 +811,7 @@ describe('File', function() {
     });
 
     it('sets _contents', function(done) {
-      var val = new Buffer('test');
+      var val = Buffer.from('test');
       var file = new File();
       file.contents = val;
       expect(file._contents).toEqual(val);
@@ -817,7 +819,7 @@ describe('File', function() {
     });
 
     it('sets a Buffer', function(done) {
-      var val = new Buffer('test');
+      var val = Buffer.from('test');
       var file = new File();
       file.contents = val;
       expect(file.contents).toEqual(val);


### PR DESCRIPTION
Refs: https://github.com/nodejs/citgm/issues/605
Refs: https://nodejs.org/api/deprecations.html#deprecations_dep0005_buffer_constructor