### PR TITLE
Add named exports in esm module

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -1,0 +1,5 @@
+import Vinyl from "./index.js";
+
+export const isVinyl = Vinyl.isVinyl;
+export const isCustomProp = Vinyl.isCustomProp;
+export default Vinyl;

--- a/package.json
+++ b/package.json
@@ -13,6 +13,13 @@
     "node": ">= 0.10"
   },
   "main": "index.js",
+  "exports": {
+    ".": {
+      "require": "./index.js",
+      "default": "./index.mjs"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "LICENSE",
     "index.js",


### PR DESCRIPTION
This is intended to be a non-breaking new feature.
This enables doing:

```js
import { isVinyl } from 'vinyl';
```

from inside `mjs` files in node.