### PR TITLE
fs.Stats constructor is deprecated, the clone-stats package replaced with the stats-cloner package.

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var Buffer = require('buffer').Buffer;
 var clone = require('clone');
 var teex = require('teex');
 var replaceExt = require('replace-ext');
-var cloneStats = require('clone-stats');
+var statsCloner = require('stats-cloner');
 var removeTrailingSep = require('remove-trailing-separator');
 
 var isStream = require('./lib/is-stream');
@@ -132,7 +132,7 @@ File.prototype.clone = function (opt) {
   var file = new this.constructor({
     cwd: this.cwd,
     base: this.base,
-    stat: this.stat ? cloneStats(this.stat) : null,
+    stat: this.stat ? statsCloner(this.stat) : null,
     history: this.history.slice(),
     contents: contents,
   });

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "clone": "^2.1.2",
-    "clone-stats": "^1.0.0",
+    "stats-cloner": "^1.1.0",
     "remove-trailing-separator": "^1.1.0",
     "replace-ext": "^2.0.0",
     "teex": "^1.0.1"


### PR DESCRIPTION
Since the fs.Stats constructor is deprecated, the clone-stats package has been replaced with the stats-cloner package.