### PR TITLE
fix: Drop clone-stats dependency by cloning with `Object.create`

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,12 +7,15 @@ var Buffer = require('buffer').Buffer;
 var clone = require('clone');
 var teex = require('teex');
 var replaceExt = require('replace-ext');
-var cloneStats = require('clone-stats');
 var removeTrailingSep = require('remove-trailing-separator');
 
 var isStream = require('./lib/is-stream');
 var normalize = require('./lib/normalize');
 var inspectStream = require('./lib/inspect-stream');
+
+function cloneObject (obj) {
+  return Object.create(Object.getPrototypeOf(obj), Object.getOwnPropertyDescriptors(obj));
+}
 
 var builtInFields = [
   '_contents',
@@ -132,7 +135,7 @@ File.prototype.clone = function (opt) {
   var file = new this.constructor({
     cwd: this.cwd,
     base: this.base,
-    stat: this.stat ? cloneStats(this.stat) : null,
+    stat: this.stat ? cloneObject(this.stat) : null,
     history: this.history.slice(),
     contents: contents,
   });

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   },
   "dependencies": {
     "clone": "^2.1.2",
-    "clone-stats": "^1.0.0",
     "remove-trailing-separator": "^1.1.0",
     "replace-ext": "^2.0.0",
     "teex": "^1.0.1"


### PR DESCRIPTION
… is deprecated.

See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptors#creating_a_shallow_copy

Related to https://github.com/gulpjs/vinyl-fs/issues/356
Related to https://github.com/gulpjs/vinyl-fs/issues/354